### PR TITLE
feat: add UserCoupon model and update coupon relation

### DIFF
--- a/prisma/migrations/20251003050552_add_usercoupon_relation/migration.sql
+++ b/prisma/migrations/20251003050552_add_usercoupon_relation/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_collected` on the `coupon` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."coupon" DROP COLUMN "is_collected";
+
+-- CreateTable
+CREATE TABLE "public"."UserCoupon" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "coupon_id" INTEGER NOT NULL,
+    "is_collected" BOOLEAN NOT NULL DEFAULT false,
+    "collected_at" TIMESTAMP(3),
+
+    CONSTRAINT "UserCoupon_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserCoupon_user_id_coupon_id_key" ON "public"."UserCoupon"("user_id", "coupon_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."UserCoupon" ADD CONSTRAINT "UserCoupon_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."UserCoupon" ADD CONSTRAINT "UserCoupon_coupon_id_fkey" FOREIGN KEY ("coupon_id") REFERENCES "public"."coupon"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,6 +169,7 @@ model user {
   avatar_id  String?
   avatar_url String?
   bookings   booking[]
+  coupons    UserCoupon[] //  relation
 }
 
 model booking {
@@ -214,7 +215,21 @@ model coupon {
   updated_at     DateTime @updatedAt
   usage_limit    Int?
   used_count     Int      @default(0)
-  is_collected   Boolean  @default(false)
+  users          UserCoupon[] //  relation
+}
+
+// Table สำหรับเชื่อม user <-> coupon
+model UserCoupon {
+  id           String   @id @default(uuid())
+  user_id      String
+  coupon_id    Int
+  is_collected Boolean  @default(false)
+  collected_at DateTime?
+
+  user   user   @relation(fields: [user_id], references: [id])
+  coupon coupon @relation(fields: [coupon_id], references: [id])
+
+  @@unique([user_id, coupon_id])
 }
 
 enum booking_status {


### PR DESCRIPTION
- Introduced UserCoupon model to establish a many-to-many relationship between users and coupons.
- Removed is_collected field from the coupon model and integrated it into the UserCoupon model.
- Updated the schema and migration files accordingly.